### PR TITLE
Feat: saving cookies

### DIFF
--- a/cookies.py
+++ b/cookies.py
@@ -1,0 +1,45 @@
+import pickle
+import pprint
+import time
+
+from selenium import webdriver
+
+## Using selenium to bypass JSTOR Login 
+
+
+def save_cookies(driver, location):
+
+    pickle.dump(driver.get_cookies(), open(location, "wb"))
+
+
+def load_cookies(driver, location, url=None):
+
+    cookies = pickle.load(open(location, "rb"))
+    driver.delete_all_cookies()
+    # have to be on a page before you can add any cookies, any page - does not matter which
+    driver.get("https://vula.uct.ac.za" if url is None else url)
+    for cookie in cookies:
+        if isinstance(cookie.get('expiry'), float):#Checks if the instance expiry a float 
+            cookie['expiry'] = int(cookie['expiry'])# it converts expiry cookie to a int 
+        driver.add_cookie(cookie)
+
+
+def delete_cookies(driver, domains=None):
+
+    if domains is not None:
+        cookies = driver.get_cookies()
+        original_len = len(cookies)
+        for cookie in cookies:
+            if str(cookie["domain"]) in domains:
+                cookies.remove(cookie)
+        if len(cookies) < original_len:  # if cookies changed, we will update them
+            # deleting everything and adding the modified cookie object
+            driver.delete_all_cookies()
+            for cookie in cookies:
+                driver.add_cookie(cookie)
+    else:
+        driver.delete_all_cookies()
+
+
+# Path where you want to save/load cookies to/from 
+cookies_location = "C:\Users\User\Desktop\MPhil\chrome\chromedriver\cookies.txt"

--- a/cookies.py
+++ b/cookies.py
@@ -1,8 +1,11 @@
 import pickle
 import pprint
-import time
 
 from selenium import webdriver
+from webdriver_manager.chrome import ChromeDriverManager
+from time import sleep
+
+
 
 ## Using selenium to bypass JSTOR Login 
 
@@ -41,5 +44,19 @@ def delete_cookies(driver, domains=None):
         driver.delete_all_cookies()
 
 
+
 # Path where you want to save/load cookies to/from 
-cookies_location = "C:\Users\User\Desktop\MPhil\chrome\chromedriver\cookies.txt"
+cookies_location = "C:/Users/User/Desktop/MPhil/chrome/chromedriver/cookies.txt"
+
+username= "" # provide uct email studentNo@myuct.ac.za
+password="" #uct vula password
+
+
+driver = webdriver.Chrome(ChromeDriverManager().install())
+driver.get('https://www-jstor-org.ezproxy.uct.ac.za')
+
+ 
+driver.find_element_by_xpath(".//input[@id='userNameInput']").send_keys(username)
+driver.find_element_by_xpath(".//input[@id='passwordInput']").send_keys(password)
+driver.find_element_by_xpath(".//span[@id='submitButton']").click()
+sleep(3)

--- a/cookies.py
+++ b/cookies.py
@@ -1,39 +1,34 @@
 import pickle
 import pprint
-import time
 
 from selenium import webdriver
-
-## Using selenium to bypass JSTOR Login 
-
+from webdriver_manager.chrome import ChromeDriverManager
+from time import sleep
 
 def save_cookies(driver, location):
-
     pickle.dump(driver.get_cookies(), open(location, "wb"))
 
 
 def load_cookies(driver, location, url=None):
-
     cookies = pickle.load(open(location, "rb"))
     driver.delete_all_cookies()
-    # have to be on a page before you can add any cookies, any page - does not matter which
+   
     driver.get("https://vula.uct.ac.za" if url is None else url)
     for cookie in cookies:
-        if isinstance(cookie.get('expiry'), float):#Checks if the instance expiry a float 
-            cookie['expiry'] = int(cookie['expiry'])# it converts expiry cookie to a int 
+        if isinstance(cookie.get('expiry'), float):
+            cookie['expiry'] = int(cookie['expiry'])
         driver.add_cookie(cookie)
 
 
 def delete_cookies(driver, domains=None):
-
     if domains is not None:
         cookies = driver.get_cookies()
         original_len = len(cookies)
         for cookie in cookies:
             if str(cookie["domain"]) in domains:
                 cookies.remove(cookie)
-        if len(cookies) < original_len:  # if cookies changed, we will update them
-            # deleting everything and adding the modified cookie object
+        if len(cookies) < original_len:  
+         
             driver.delete_all_cookies()
             for cookie in cookies:
                 driver.add_cookie(cookie)
@@ -41,5 +36,19 @@ def delete_cookies(driver, domains=None):
         driver.delete_all_cookies()
 
 
-# Path where you want to save/load cookies to/from 
 cookies_location = "C:\Users\User\Desktop\MPhil\chrome\chromedriver\cookies.txt"
+
+
+username= "" # provide uct email studentNo@myuct.ac.za
+password="" #uct vula password
+
+
+driver = webdriver.Chrome(ChromeDriverManager().install())
+driver.get('https://www-jstor-org.ezproxy.uct.ac.za')
+
+ 
+driver.find_element_by_xpath(".//input[@id='userNameInput']").send_keys(username)
+driver.find_element_by_xpath(".//input[@id='passwordInput']").send_keys(password)
+driver.find_element_by_xpath(".//span[@id='submitButton']").click()
+sleep(3)
+

--- a/cookies.py
+++ b/cookies.py
@@ -1,11 +1,8 @@
 import pickle
 import pprint
+import time
 
 from selenium import webdriver
-from webdriver_manager.chrome import ChromeDriverManager
-from time import sleep
-
-
 
 ## Using selenium to bypass JSTOR Login 
 
@@ -44,19 +41,5 @@ def delete_cookies(driver, domains=None):
         driver.delete_all_cookies()
 
 
-
 # Path where you want to save/load cookies to/from 
-cookies_location = "C:/Users/User/Desktop/MPhil/chrome/chromedriver/cookies.txt"
-
-username= "" # provide uct email studentNo@myuct.ac.za
-password="" #uct vula password
-
-
-driver = webdriver.Chrome(ChromeDriverManager().install())
-driver.get('https://www-jstor-org.ezproxy.uct.ac.za')
-
- 
-driver.find_element_by_xpath(".//input[@id='userNameInput']").send_keys(username)
-driver.find_element_by_xpath(".//input[@id='passwordInput']").send_keys(password)
-driver.find_element_by_xpath(".//span[@id='submitButton']").click()
-sleep(3)
+cookies_location = "C:\Users\User\Desktop\MPhil\chrome\chromedriver\cookies.txt"


### PR DESCRIPTION
# Pull Request
Task 156( Save Vula cookie string locally on your computer). 
(https://dev.azure.com/SWLRAC001/Data%20Retrieval%20Team/_workitems/156)

## Scope
## Work Done
Uses a web driver to log on to Vula, save cookies locally on a computer to use them at a later stage to automatically log on to JSTOR. The cookies are automatically modified if they change. 

## Steps to Test
Create a folder on your computer where you want to save/load cookies to/from aka C:\my\fav\directory\cookies.txt
For now, the code does not load cookies. 
