### PR TITLE
refactor: Encapsulate scraper into class

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -133,3 +133,6 @@ dmypy.json
 node_modules/
 npm-debug.log
 yarn-error.log
+
+# Secure files that we don't want uploaded
+cookiefile.txt

--- a/main.py
+++ b/main.py
@@ -1,0 +1,68 @@
+from scraper.scraper import JstorScraper
+import requests
+import scraper
+import re
+from pathlib import Path
+
+USER_AGENT = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/92.0.4515.159 Safari/537.36'
+
+PAPER_ID = '2629139'
+
+OUT_FILE = r'F:\woo.pdf'
+
+# Converts a request's cookie string into a dictionary that we can use with requests.
+def parse_cookies(cookiestring: str) -> dict:
+
+    # The UCT session cookies have messy formats that http.cookies doesn't like
+    # We have to manually parse - this may be fragile!
+
+    cookies = {}
+    kv_regex = re.compile(r'(?P<key>[^;=]+)=(?P<val>[^;]*);')
+    
+    for c in kv_regex.finditer(cookiestring):
+        cookies[c.group('key')] = c.group('val')
+
+    return cookies
+
+def uct_rewrite(instring: str) -> str:
+    # Hopefully this regex will handle most real-world cases that we need
+    url_regex = re.compile(r'(?P<proto>https?)://(?P<host>[-A-Za-z.]+)(?P<port>:[0-9]+)?(?P<pathqry>/.+)?')
+
+    url_match = url_regex.fullmatch(instring)
+
+    if url_match == None or url_match['host'] == None: 
+        raise ValueError('instring does not appear to be a useable URL')
+
+    # Generating rewritten string using string interpolation
+    retval = f'https://{url_match["host"].replace(".", "-")}.ezproxy.uct.ac.za{str(url_match["port"] or "")}{str(url_match["pathqry"] or "")}'
+
+    return retval
+
+# --------------------------------------------------
+# Code that runs test: 
+
+#print(uct_rewrite(test_uri))
+
+with open(r'cookiefile.txt', 'r') as cookiedata:
+
+    cookietext = cookiedata.readline()
+
+cookies = parse_cookies(cookietext)
+
+#print(cookies)
+
+session = requests.Session()
+
+with session as s:
+
+    s.headers['User-Agent'] = USER_AGENT
+
+    s.cookies.update(cookies)
+
+    print(s.cookies)
+
+    the_scraper = JstorScraper(s, uct_rewrite)
+
+    initreq = the_scraper.get_payload_data(PAPER_ID)
+
+    initreq.save_pdf(Path(OUT_FILE))


### PR DESCRIPTION
# Pull Request

## Scope

scraper was neatened up into a standalone package that can be `import`ed. Created main.py that in theory can be used as the base for the actual AaronsKit program

## Work Done

scraper code and API substantially cleaned up, and docstrings added to assist with future usage. Added ability to have a custom URL rewriter if, for example, using a different university's proxy. Created main.py that mostly just has tests for now

## Steps to Test

Create a file called cookiefile.txt in the information-retrieval root. You can paste the cookie contents into here instead of the code now. Then run main.py.

WARNING: For unknown reasons JSTOR has started being able to pick up that this is bot traffic. CRITICALLY NEEDS FURTHER INVESTIGATION.
